### PR TITLE
Bunch of miscellaneous changes to SCA, Student, Course, Tutorial Structure

### DIFF
--- a/src/main/java/tahub/contacts/logic/Messages.java
+++ b/src/main/java/tahub/contacts/logic/Messages.java
@@ -1,5 +1,7 @@
 package tahub.contacts.logic;
 
+import static java.util.Objects.requireNonNull;
+
 import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
@@ -7,6 +9,7 @@ import java.util.stream.Stream;
 import tahub.contacts.logic.parser.Prefix;
 import tahub.contacts.model.course.Course;
 import tahub.contacts.model.person.Person;
+import tahub.contacts.model.studentcourseassociation.StudentCourseAssociation;
 
 /**
  * Container for user visible messages.
@@ -15,6 +18,8 @@ public class Messages {
 
     public static final String MESSAGE_UNKNOWN_COMMAND = "Unknown command";
     public static final String MESSAGE_INVALID_COMMAND_FORMAT = "Invalid command format! \n%1$s";
+    public static final String MESSAGE_INVALID_COMMAND_MISSING_FIELDS =
+            "Invalid command format, required fields are missing! \n%1$s";
     public static final String MESSAGE_INVALID_PERSON_DISPLAYED_INDEX = "The person index provided is invalid";
     public static final String MESSAGE_PERSONS_LISTED_OVERVIEW = "%1$d persons listed!";
     public static final String MESSAGE_DUPLICATE_FIELDS =
@@ -56,6 +61,18 @@ public class Messages {
     public static String format(Course course) {
         // Implement the formatting logic for Course objects
         return course.toString();
+    }
+
+    /**
+     * Formats the {@link StudentCourseAssociation} for display to the user.
+     * <p></p>
+     * This is in the form {@code <matricNumber>; <tutorialId>-<course>}
+     */
+    public static String format(StudentCourseAssociation sca) {
+        requireNonNull(sca);
+        return sca.getStudent().toStringShort()
+                + "; " + sca.getTutorial()
+                + "-" + sca.getCourse();
     }
 
 }

--- a/src/main/java/tahub/contacts/logic/parser/CliSyntax.java
+++ b/src/main/java/tahub/contacts/logic/parser/CliSyntax.java
@@ -13,5 +13,6 @@ public class CliSyntax {
     public static final Prefix PREFIX_ADDRESS = new Prefix("a/");
     public static final Prefix PREFIX_TAG = new Prefix("t/");
     public static final Prefix PREFIX_CODE = new Prefix("c/");
+    public static final Prefix PREFIX_TUTORIAL = new Prefix("tut/");
 
 }

--- a/src/main/java/tahub/contacts/logic/parser/ParserUtil.java
+++ b/src/main/java/tahub/contacts/logic/parser/ParserUtil.java
@@ -5,6 +5,7 @@ import static java.util.Objects.requireNonNull;
 import java.util.Collection;
 import java.util.HashSet;
 import java.util.Set;
+import java.util.stream.Stream;
 
 import tahub.contacts.commons.core.index.Index;
 import tahub.contacts.commons.util.StringUtil;
@@ -17,12 +18,23 @@ import tahub.contacts.model.person.MatriculationNumber;
 import tahub.contacts.model.person.Name;
 import tahub.contacts.model.person.Phone;
 import tahub.contacts.model.tag.Tag;
+import tahub.contacts.model.tutorial.Tutorial;
 
 /**
  * Contains utility methods used for parsing strings in the various *Parser classes.
  */
 public class ParserUtil {
     public static final String MESSAGE_INVALID_INDEX = "Index is not a non-zero unsigned integer.";
+
+    /**
+     * Returns true if none of the prefixes contains empty {@code Optional} values in the given
+     * {@code ArgumentMultimap}.
+     */
+    public static boolean arePrefixesPresent(ArgumentMultimap argumentMultimap, Prefix... prefixes) {
+        return Stream.of(prefixes).allMatch(prefix -> argumentMultimap.getValue(prefix).isPresent());
+    }
+
+    // ===================================== SPECIFIC PARSERS ===============================================
 
     /**
      * Parses {@code oneBasedIndex} into an {@code Index} and returns it. Leading and trailing whitespaces will be
@@ -167,5 +179,21 @@ public class ParserUtil {
             throw new ParseException(CourseName.MESSAGE_CONSTRAINTS);
         }
         return new CourseName(trimmedCourseName);
+    }
+
+    /**
+     * Parses a {@code String tutorialId}.
+     * Leading and trailing whitespaces will be trimmed.
+     *
+     * @return trimmed tutorial ID as a {@code String}.
+     * @throws ParseException if the given {@code tutorialId} is invalid.
+     */
+    public static String parseTutorialId(String tutorialId) throws ParseException {
+        requireNonNull(tutorialId);
+        String trimmedTutorialId = tutorialId.trim();
+        if (!Tutorial.isValidTutorialId(trimmedTutorialId)) {
+            throw new ParseException(Tutorial.TUTORIAL_ID_MESSAGE_CONSTRAINTS);
+        }
+        return trimmedTutorialId;
     }
 }

--- a/src/main/java/tahub/contacts/model/course/Course.java
+++ b/src/main/java/tahub/contacts/model/course/Course.java
@@ -55,7 +55,7 @@ public class Course {
      * Format state as text for viewing.
      */
     public String toString() {
-        return courseCode.toString() + ": " + courseName.toString();
+        return "[" + courseCode.toString() + ": " + courseName.toString() + "]";
     }
 
 }

--- a/src/main/java/tahub/contacts/model/course/Course.java
+++ b/src/main/java/tahub/contacts/model/course/Course.java
@@ -55,7 +55,7 @@ public class Course {
      * Format state as text for viewing.
      */
     public String toString() {
-        return '[' + courseCode.toString() + ": " + courseName.toString() + ']';
+        return courseCode.toString() + ": " + courseName.toString();
     }
 
 }

--- a/src/main/java/tahub/contacts/model/person/Person.java
+++ b/src/main/java/tahub/contacts/model/person/Person.java
@@ -157,4 +157,13 @@ public class Person {
                 .add("tags", tags)
                 .toString();
     }
+
+    /**
+     * Shortened string representation of this {@link Person}. Only includes the matriculation number.
+     *
+     * @return String representation in {@code [matricNumber]} form
+     */
+    public String toStringShort() {
+        return "[" + matricNumber.toString() + "]";
+    }
 }

--- a/src/main/java/tahub/contacts/model/person/Person.java
+++ b/src/main/java/tahub/contacts/model/person/Person.java
@@ -1,5 +1,6 @@
 package tahub.contacts.model.person;
 
+import static java.util.Objects.requireNonNull;
 import static tahub.contacts.commons.util.CollectionUtil.requireAllNonNull;
 
 import java.util.Collections;
@@ -43,6 +44,24 @@ public class Person {
         this.email = email;
         this.address = address;
         this.tags.addAll(tags);
+    }
+
+    /**
+     * Creates a {@link Person} with generic details, taking in only a {@link MatriculationNumber}.
+     *
+     * @param matricNumber Matriculation number.
+     * @return Person.
+     */
+    public static Person genericFromMatricNumber(MatriculationNumber matricNumber) {
+        requireNonNull(matricNumber);
+        return new Person(
+                matricNumber,
+                new Name("generic"),
+                new Phone("99999999"),
+                new Email("local@domain.tld"),
+                new Address("404 Address Not Found"),
+                new HashSet<>()
+        );
     }
 
     public MatriculationNumber getMatricNumber() {

--- a/src/main/java/tahub/contacts/model/person/Person.java
+++ b/src/main/java/tahub/contacts/model/person/Person.java
@@ -161,9 +161,9 @@ public class Person {
     /**
      * Shortened string representation of this {@link Person}. Only includes the matriculation number.
      *
-     * @return String representation in {@code [matricNumber]} form
+     * @return String representation in "{@code matricNumber}" form
      */
     public String toStringShort() {
-        return "[" + matricNumber.toString() + "]";
+        return matricNumber.toString();
     }
 }

--- a/src/main/java/tahub/contacts/model/person/Person.java
+++ b/src/main/java/tahub/contacts/model/person/Person.java
@@ -59,7 +59,7 @@ public class Person {
                 new Name("generic"),
                 new Phone("99999999"),
                 new Email("local@domain.tld"),
-                new Address("404 Address Not Found"),
+                new Address("Generic Address St."),
                 new HashSet<>()
         );
     }

--- a/src/main/java/tahub/contacts/model/person/Person.java
+++ b/src/main/java/tahub/contacts/model/person/Person.java
@@ -47,7 +47,7 @@ public class Person {
     }
 
     /**
-     * Creates a {@link Person} with generic details, taking in only a {@link MatriculationNumber}.
+     * Creates a valid {@link Person} with generic details, taking in only a {@link MatriculationNumber}.
      *
      * @param matricNumber Matriculation number.
      * @return Person.

--- a/src/main/java/tahub/contacts/model/studentcourseassociation/StudentCourseAssociation.java
+++ b/src/main/java/tahub/contacts/model/studentcourseassociation/StudentCourseAssociation.java
@@ -185,4 +185,9 @@ public class StudentCourseAssociation {
 
         return this.tutorial.equals(otherStudentCourseAssociation.tutorial);
     }
+
+    @Override
+    public String toString() {
+        return student.toStringShort() + " - " + course.toString() + " - " + tutorial.toString();
+    }
 }

--- a/src/main/java/tahub/contacts/model/studentcourseassociation/StudentCourseAssociation.java
+++ b/src/main/java/tahub/contacts/model/studentcourseassociation/StudentCourseAssociation.java
@@ -177,7 +177,7 @@ public class StudentCourseAssociation {
 
         StudentCourseAssociation otherStudentCourseAssociation = (StudentCourseAssociation) other;
         boolean checkStudentAndCourse = this.student.equals(otherStudentCourseAssociation.student)
-                && this.course.equals(otherStudentCourseAssociation.course);
+                && this.course.isConflictCourse(otherStudentCourseAssociation.course);
 
         if (!checkStudentAndCourse) {
             return false;

--- a/src/main/java/tahub/contacts/model/studentcourseassociation/StudentCourseAssociation.java
+++ b/src/main/java/tahub/contacts/model/studentcourseassociation/StudentCourseAssociation.java
@@ -177,13 +177,30 @@ public class StudentCourseAssociation {
 
         StudentCourseAssociation otherStudentCourseAssociation = (StudentCourseAssociation) other;
         boolean checkStudentAndCourse = this.student.equals(otherStudentCourseAssociation.student)
-                && this.course.isConflictCourse(otherStudentCourseAssociation.course);
+                && this.course.equals(otherStudentCourseAssociation.course);
 
         if (!checkStudentAndCourse) {
             return false;
         }
 
         return this.tutorial.equals(otherStudentCourseAssociation.tutorial);
+    }
+
+    /**
+     * Compares this {@code StudentCourseAssociation} with another {@code StudentCourseAssociation} for equality
+     * based on the primary identifiers: matriculation number, course code, and tutorial ID.
+     *
+     * @param other The other {@code StudentCourseAssociation} to compare this {@code StudentCourseAssociation} with
+     * @return true if the two SCAs are equal, false otherwise
+     */
+    public boolean isSameSca(StudentCourseAssociation other) {
+        if (other == this) {
+            return true;
+        }
+
+        return this.student.isSamePerson(other.student)
+                && this.course.isConflictCourse(other.course)
+                && this.tutorial.equals(other.tutorial);
     }
 
     @Override

--- a/src/main/java/tahub/contacts/model/studentcourseassociation/StudentCourseAssociationList.java
+++ b/src/main/java/tahub/contacts/model/studentcourseassociation/StudentCourseAssociationList.java
@@ -10,7 +10,10 @@ import java.util.List;
 import javafx.collections.FXCollections;
 import javafx.collections.ObservableList;
 import tahub.contacts.model.course.Course;
+import tahub.contacts.model.course.CourseCode;
+import tahub.contacts.model.course.CourseName;
 import tahub.contacts.model.course.UniqueCourseList;
+import tahub.contacts.model.person.MatriculationNumber;
 import tahub.contacts.model.person.Person;
 import tahub.contacts.model.tutorial.Tutorial;
 
@@ -110,19 +113,21 @@ public class StudentCourseAssociationList implements Iterable<StudentCourseAssoc
         return courseTutorialScas;
     }
 
+
+
     /**
      * Returns the SCA list of a student by matric number.
      */
     public ObservableList<StudentCourseAssociation> getByMatric(String matricNumber) {
         ObservableList<StudentCourseAssociation> studentScas = FXCollections.observableArrayList();
         for (StudentCourseAssociation sca : internalList) {
-            if (sca.getStudent().getMatricNumber().equals(matricNumber)) {
+            if (sca.getStudent().getMatricNumber().equals(new MatriculationNumber(matricNumber))) {
                 studentScas.add(sca);
             }
         }
         return studentScas;
     }
-
+    
     /**
      * Replaces the SCA {@code target} in the list with {@code editedSca}.
      * {@code target} must exist in the list.

--- a/src/main/java/tahub/contacts/model/studentcourseassociation/StudentCourseAssociationList.java
+++ b/src/main/java/tahub/contacts/model/studentcourseassociation/StudentCourseAssociationList.java
@@ -15,6 +15,7 @@ import tahub.contacts.model.course.CourseName;
 import tahub.contacts.model.course.UniqueCourseList;
 import tahub.contacts.model.person.MatriculationNumber;
 import tahub.contacts.model.person.Person;
+import tahub.contacts.model.studentcourseassociation.exceptions.ScaNotFoundException;
 import tahub.contacts.model.tutorial.Tutorial;
 
 /**
@@ -156,7 +157,7 @@ public class StudentCourseAssociationList implements Iterable<StudentCourseAssoc
                         && sca.getCourse().isConflictCourse(compCourse) && sca.getTutorial().equals(compTutorial)
                 )
                 .findFirst()
-                .orElseThrow(() -> new RuntimeException(notFoundErrorMessage));
+                .orElseThrow(() -> new ScaNotFoundException(notFoundErrorMessage));
     }
 
     /**

--- a/src/main/java/tahub/contacts/model/studentcourseassociation/StudentCourseAssociationList.java
+++ b/src/main/java/tahub/contacts/model/studentcourseassociation/StudentCourseAssociationList.java
@@ -127,7 +127,38 @@ public class StudentCourseAssociationList implements Iterable<StudentCourseAssoc
         }
         return studentScas;
     }
-    
+
+    /**
+     * Returns an SCA based on the matriculation number, course code, and tutorial code as string queries.
+     * Throws a {@link RuntimeException} if an SCA matching the query is not found.
+     *
+     * @param matricNumber The matriculation number.
+     * @param courseCodeString The course code.
+     * @param tutorialCodeString The tutorial code.
+     * @return The SCA matching the queries, if one is found.
+     */
+    public StudentCourseAssociation getFromStrings(
+            String matricNumber, String courseCodeString, String tutorialCodeString) {
+        requireAllNonNull(matricNumber, courseCodeString, tutorialCodeString);
+
+        MatriculationNumber compMatricNumber = new MatriculationNumber(matricNumber);
+        Course compCourse = new Course(new CourseCode(courseCodeString), new CourseName("COURSE NAME PLACEHOLDER"));
+        Tutorial compTutorial = new Tutorial(tutorialCodeString, compCourse);
+
+        String notFoundErrorMessage = String.format(
+                "SCA not found for the query: %s, %s, %s",
+                matricNumber, courseCodeString, tutorialCodeString);
+
+        return internalList
+                .stream()
+                .filter(sca ->
+                        sca.getStudent().getMatricNumber().equals(compMatricNumber)
+                        && sca.getCourse().isConflictCourse(compCourse) && sca.getTutorial().equals(compTutorial)
+                )
+                .findFirst()
+                .orElseThrow(() -> new RuntimeException(notFoundErrorMessage));
+    }
+
     /**
      * Replaces the SCA {@code target} in the list with {@code editedSca}.
      * {@code target} must exist in the list.

--- a/src/main/java/tahub/contacts/model/studentcourseassociation/StudentCourseAssociationList.java
+++ b/src/main/java/tahub/contacts/model/studentcourseassociation/StudentCourseAssociationList.java
@@ -142,6 +142,8 @@ public class StudentCourseAssociationList implements Iterable<StudentCourseAssoc
             String matricNumber, String courseCodeString, String tutorialCodeString) {
         requireAllNonNull(matricNumber, courseCodeString, tutorialCodeString);
 
+        // not used - can remove?
+
         MatriculationNumber compMatricNumber = new MatriculationNumber(matricNumber);
         Course compCourse = new Course(new CourseCode(courseCodeString), new CourseName("COURSE NAME PLACEHOLDER"));
         Tutorial compTutorial = new Tutorial(tutorialCodeString, compCourse);
@@ -156,6 +158,26 @@ public class StudentCourseAssociationList implements Iterable<StudentCourseAssoc
                         sca.getStudent().getMatricNumber().equals(compMatricNumber)
                         && sca.getCourse().isConflictCourse(compCourse) && sca.getTutorial().equals(compTutorial)
                 )
+                .findFirst()
+                .orElseThrow(() -> new ScaNotFoundException(notFoundErrorMessage));
+    }
+
+    /**
+     * Returns a matching SCA based on an input query SCA. This query will be matched against the SCAs in this list
+     * based on the {@link MatriculationNumber}, {@link CourseCode} and tutorial ID {@code String}.
+     * <p></p>
+     * Throws a {@link RuntimeException} if an SCA matching the query is not found.
+     *
+     * @param toFind SCA with the {@link MatriculationNumber}, {@link CourseCode} and tutorial ID to look for.
+     * @return The SCA matching the queries, if one is found.
+     */
+    public StudentCourseAssociation findMatch(StudentCourseAssociation toFind) {
+        String notFoundErrorMessage = String.format(
+                "SCA not found for the query SCA: %s",
+                toFind);
+
+        return internalList.stream()
+                .filter(sca -> sca.isSameSca(toFind))
                 .findFirst()
                 .orElseThrow(() -> new ScaNotFoundException(notFoundErrorMessage));
     }

--- a/src/main/java/tahub/contacts/model/studentcourseassociation/exceptions/ScaNotFoundException.java
+++ b/src/main/java/tahub/contacts/model/studentcourseassociation/exceptions/ScaNotFoundException.java
@@ -1,0 +1,11 @@
+package tahub.contacts.model.studentcourseassociation.exceptions;
+
+/**
+ * Signals that the operation is unable to find a/the desired
+ * {@link tahub.contacts.model.studentcourseassociation.StudentCourseAssociation}.
+ */
+public class ScaNotFoundException extends RuntimeException {
+    public ScaNotFoundException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/tahub/contacts/model/tutorial/Tutorial.java
+++ b/src/main/java/tahub/contacts/model/tutorial/Tutorial.java
@@ -75,7 +75,7 @@ public class Tutorial {
 
         Tutorial otherTutorial = (Tutorial) other;
         return this.tutorialId.equals(otherTutorial.tutorialId)
-                && this.course.equals(otherTutorial.course);
+                && this.course.isConflictCourse(otherTutorial.course);
     }
 
     @Override

--- a/src/main/java/tahub/contacts/model/tutorial/Tutorial.java
+++ b/src/main/java/tahub/contacts/model/tutorial/Tutorial.java
@@ -83,4 +83,9 @@ public class Tutorial {
         // use this method for custom fields hashing instead of implementing your own
         return Objects.hash(this.tutorialId, this.course);
     }
+
+    Override
+    public String toString() {
+        return tutorialId;
+    }
 }

--- a/src/main/java/tahub/contacts/model/tutorial/Tutorial.java
+++ b/src/main/java/tahub/contacts/model/tutorial/Tutorial.java
@@ -84,7 +84,7 @@ public class Tutorial {
         return Objects.hash(this.tutorialId, this.course);
     }
 
-    Override
+    @Override
     public String toString() {
         return tutorialId;
     }

--- a/src/main/java/tahub/contacts/model/tutorial/Tutorial.java
+++ b/src/main/java/tahub/contacts/model/tutorial/Tutorial.java
@@ -14,7 +14,7 @@ public class Tutorial {
 
     public static final String TUTORIAL_ID_MESSAGE_CONSTRAINTS =
             "Tutorial Id should start with T, followed by exactly 2 digits between 01 and 99"
-                    + "e.g., T05, T56 or T98";
+                    + ", e.g., T05, T56 or T98";
     /**
      * Represents the regex pattern for validating course codes.
      * The course code should start with 'T', followed by a number from 01 to 99, as per NUS's

--- a/src/test/java/tahub/contacts/model/person/PersonTest.java
+++ b/src/test/java/tahub/contacts/model/person/PersonTest.java
@@ -16,6 +16,7 @@ import static tahub.contacts.testutil.TypicalPersons.BOB;
 import java.util.HashSet;
 import java.util.List;
 
+import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
 import tahub.contacts.logic.Logic;
@@ -38,6 +39,16 @@ public class PersonTest {
     public void asObservableList_modifyList_throwsUnsupportedOperationException() {
         Person person = new PersonBuilder().build();
         assertThrows(UnsupportedOperationException.class, () -> person.getTags().remove(0));
+    }
+
+    @Test
+    @DisplayName("Generic MatricNumber-only factory method genericFromMatricNumber() returns "
+            + "Persons with correct matric Number")
+    public void genericFromMatricNumber_validMatricNumberInput_createdObjectHasCorrectMatricNumber() {
+        MatriculationNumber mn1 = new MatriculationNumber("A0000000X");
+        MatriculationNumber mn2 = new MatriculationNumber("A1234567X");
+        assertEquals(Person.genericFromMatricNumber(mn1).getMatricNumber(), mn1);
+        assertEquals(Person.genericFromMatricNumber(mn2).getMatricNumber(), mn2);
     }
 
     @Test

--- a/src/test/java/tahub/contacts/model/studentcourseassociation/StudentCourseAssociationListTest.java
+++ b/src/test/java/tahub/contacts/model/studentcourseassociation/StudentCourseAssociationListTest.java
@@ -1,12 +1,15 @@
 package tahub.contacts.model.studentcourseassociation;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 
 import javafx.collections.FXCollections;
@@ -82,5 +85,24 @@ public class StudentCourseAssociationListTest {
         List<Tutorial> filteredTutorials = scaList.filterTutorialsByStudent(student1);
         List<Tutorial> expectedTutorials = List.of(tutorial1, tutorial2);
         assertEquals(expectedTutorials, filteredTutorials);
+    }
+
+    @Nested
+    @DisplayName("getFromStrings()")
+    class GetFromStrings {
+        @Test
+        @DisplayName("finds correct SCA if SCA is in list")
+        public void findsSca_ScaInList() {
+            StudentCourseAssociation foundSca = scaList.getFromStrings(
+                    "A1234567X", "CS1010", "T01");
+            assertEquals(foundSca, sca1);
+        }
+
+        @Test
+        @DisplayName("throws runtime exception if SCA is not in list but inputs are valid")
+        public void throwsRuntimeException_ScaNotInListInputsValid() {
+            assertThrows(RuntimeException.class, () -> scaList.getFromStrings(
+                    "A1234567X", "AB2000", "T02"));
+        }
     }
 }

--- a/src/test/java/tahub/contacts/model/studentcourseassociation/StudentCourseAssociationListTest.java
+++ b/src/test/java/tahub/contacts/model/studentcourseassociation/StudentCourseAssociationListTest.java
@@ -27,6 +27,7 @@ import tahub.contacts.model.person.Phone;
 import tahub.contacts.model.studentcourseassociation.exceptions.ScaNotFoundException;
 import tahub.contacts.model.tag.Tag;
 import tahub.contacts.model.tutorial.Tutorial;
+import tahub.contacts.testutil.PersonBuilder;
 
 public class StudentCourseAssociationListTest {
 
@@ -104,6 +105,36 @@ public class StudentCourseAssociationListTest {
         public void throwsRuntimeException_ScaNotInListInputsValid() {
             assertThrows(ScaNotFoundException.class, () -> scaList.getFromStrings(
                     "A1234567X", "AB2000", "T02"));
+        }
+    }
+
+    @Nested
+    @DisplayName("findMatch()")
+    class FindMatch {
+        @Test
+        @DisplayName("finds correct SCA if SCA with same matricNumber, courseCode, tutorialId is in list")
+        public void findsSca_ScaInList() {
+            Course course = new Course(new CourseCode("CS1010"), new CourseName("Different Name"));
+            StudentCourseAssociation toFind = new StudentCourseAssociation(
+                    new PersonBuilder().withMatriculationNumber("A1234567X").build(),
+                    course,
+                    new Tutorial("T01", course)
+            );
+            StudentCourseAssociation foundSca = scaList.findMatch(toFind);
+            assertEquals(foundSca, sca1);
+        }
+
+        @Test
+        @DisplayName("throws ScaNotFoundException if SCA with same IDs is not in list")
+        public void throwsScaNotFoundException_ScaNotInListInputsValid() {
+            Course course = new Course(new CourseCode("AA0000"), new CourseName("Different Name"));
+            StudentCourseAssociation toFind = new StudentCourseAssociation(
+                    new PersonBuilder().withMatriculationNumber("A4529999X").build(),
+                    course,
+                    new Tutorial("T99", course)
+            );
+
+            assertThrows(ScaNotFoundException.class, () -> scaList.findMatch(toFind));
         }
     }
 }

--- a/src/test/java/tahub/contacts/model/studentcourseassociation/StudentCourseAssociationListTest.java
+++ b/src/test/java/tahub/contacts/model/studentcourseassociation/StudentCourseAssociationListTest.java
@@ -94,7 +94,7 @@ public class StudentCourseAssociationListTest {
     class GetFromStrings {
         @Test
         @DisplayName("finds correct SCA if SCA is in list")
-        public void findsSca_ScaInList() {
+        public void findsSca_scaInList() {
             StudentCourseAssociation foundSca = scaList.getFromStrings(
                     "A1234567X", "CS1010", "T01");
             assertEquals(foundSca, sca1);
@@ -102,7 +102,7 @@ public class StudentCourseAssociationListTest {
 
         @Test
         @DisplayName("throws runtime exception if SCA is not in list but inputs are valid")
-        public void throwsRuntimeException_ScaNotInListInputsValid() {
+        public void throwsRuntimeException_scaNotInListInputsValid() {
             assertThrows(ScaNotFoundException.class, () -> scaList.getFromStrings(
                     "A1234567X", "AB2000", "T02"));
         }
@@ -113,7 +113,7 @@ public class StudentCourseAssociationListTest {
     class FindMatch {
         @Test
         @DisplayName("finds correct SCA if SCA with same matricNumber, courseCode, tutorialId is in list")
-        public void findsSca_ScaInList() {
+        public void findsSca_scaInList() {
             Course course = new Course(new CourseCode("CS1010"), new CourseName("Different Name"));
             StudentCourseAssociation toFind = new StudentCourseAssociation(
                     new PersonBuilder().withMatriculationNumber("A1234567X").build(),
@@ -126,7 +126,7 @@ public class StudentCourseAssociationListTest {
 
         @Test
         @DisplayName("throws ScaNotFoundException if SCA with same IDs is not in list")
-        public void throwsScaNotFoundException_ScaNotInListInputsValid() {
+        public void throwsScaNotFoundException_scaNotInListInputsValid() {
             Course course = new Course(new CourseCode("AA0000"), new CourseName("Different Name"));
             StudentCourseAssociation toFind = new StudentCourseAssociation(
                     new PersonBuilder().withMatriculationNumber("A4529999X").build(),

--- a/src/test/java/tahub/contacts/model/studentcourseassociation/StudentCourseAssociationListTest.java
+++ b/src/test/java/tahub/contacts/model/studentcourseassociation/StudentCourseAssociationListTest.java
@@ -24,6 +24,7 @@ import tahub.contacts.model.person.MatriculationNumber;
 import tahub.contacts.model.person.Name;
 import tahub.contacts.model.person.Person;
 import tahub.contacts.model.person.Phone;
+import tahub.contacts.model.studentcourseassociation.exceptions.ScaNotFoundException;
 import tahub.contacts.model.tag.Tag;
 import tahub.contacts.model.tutorial.Tutorial;
 
@@ -101,7 +102,7 @@ public class StudentCourseAssociationListTest {
         @Test
         @DisplayName("throws runtime exception if SCA is not in list but inputs are valid")
         public void throwsRuntimeException_ScaNotInListInputsValid() {
-            assertThrows(RuntimeException.class, () -> scaList.getFromStrings(
+            assertThrows(ScaNotFoundException.class, () -> scaList.getFromStrings(
                     "A1234567X", "AB2000", "T02"));
         }
     }

--- a/src/test/java/tahub/contacts/model/studentcourseassociation/StudentCourseAssociationTest.java
+++ b/src/test/java/tahub/contacts/model/studentcourseassociation/StudentCourseAssociationTest.java
@@ -205,15 +205,15 @@ class StudentCourseAssociationTest {
     @Nested
     @DisplayName("isSameSca")
     class IsSameSca {
-        Person stuRef = new PersonBuilder().build();
-        Person stuDiffMatricNo = new PersonBuilder().withMatriculationNumber("A9999999X").build();
-        Person stuDiffName = new PersonBuilder().withName("Name Different").build();
-        Course courseRef = new Course(new CourseCode("AA1000"), new CourseName("Reference Course"));
-        Course courseDiffName = new Course(new CourseCode("AA1000"), new CourseName("Different Name"));
-        Course courseDiffCode = new Course(new CourseCode("XX9999"), new CourseName("Reference Course"));
-        Tutorial tutorialRef = new Tutorial("T01", courseRef);
-        Tutorial tutorialDiffId = new Tutorial("T22", courseRef);
-        Tutorial tutorialDiffCourse = new Tutorial("T01", courseDiffCode);
+        private Person stuRef = new PersonBuilder().build();
+        private Person stuDiffMatricNo = new PersonBuilder().withMatriculationNumber("A9999999X").build();
+        private Person stuDiffName = new PersonBuilder().withName("Name Different").build();
+        private Course courseRef = new Course(new CourseCode("AA1000"), new CourseName("Reference Course"));
+        private Course courseDiffName = new Course(new CourseCode("AA1000"), new CourseName("Different Name"));
+        private Course courseDiffCode = new Course(new CourseCode("XX9999"), new CourseName("Reference Course"));
+        private Tutorial tutorialRef = new Tutorial("T01", courseRef);
+        private Tutorial tutorialDiffId = new Tutorial("T22", courseRef);
+        private Tutorial tutorialDiffCourse = new Tutorial("T01", courseDiffCode);
 
         @Test
         @DisplayName("returns true when SCAs have same student, course, tutorial object")

--- a/src/test/java/tahub/contacts/model/studentcourseassociation/StudentCourseAssociationTest.java
+++ b/src/test/java/tahub/contacts/model/studentcourseassociation/StudentCourseAssociationTest.java
@@ -11,6 +11,8 @@ import static tahub.contacts.testutil.AttendanceExamples.ATTENDANCE_EXAMPLE_1;
 import java.util.HashSet;
 import java.util.Map;
 
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 
 import tahub.contacts.model.course.Course;
@@ -24,7 +26,7 @@ import tahub.contacts.model.person.Name;
 import tahub.contacts.model.person.Person;
 import tahub.contacts.model.person.Phone;
 import tahub.contacts.model.tutorial.Tutorial;
-
+import tahub.contacts.testutil.PersonBuilder;
 
 
 class StudentCourseAssociationTest {
@@ -199,6 +201,47 @@ class StudentCourseAssociationTest {
                 new GradingSystem(), ATTENDANCE_EXAMPLE_1);
         assertFalse(sca1.equals(sca2));
     }
+
+    @Nested
+    @DisplayName("isSameSca")
+    class IsSameSca {
+        Person stuRef = new PersonBuilder().build();
+        Person stuDiffMatricNo = new PersonBuilder().withMatriculationNumber("A9999999X").build();
+        Person stuDiffName = new PersonBuilder().withName("Name Different").build();
+        Course courseRef = new Course(new CourseCode("AA1000"), new CourseName("Reference Course"));
+        Course courseDiffName = new Course(new CourseCode("AA1000"), new CourseName("Different Name"));
+        Course courseDiffCode = new Course(new CourseCode("XX9999"), new CourseName("Reference Course"));
+        Tutorial tutorialRef = new Tutorial("T01", courseRef);
+        Tutorial tutorialDiffId = new Tutorial("T22", courseRef);
+        Tutorial tutorialDiffCourse = new Tutorial("T01", courseDiffCode);
+
+        @Test
+        @DisplayName("returns true when SCAs have same student, course, tutorial object")
+        public void returnsTrue_sameStudentCourseTutorial() {
+            StudentCourseAssociation sca1 = new StudentCourseAssociation(stuRef, courseRef, tutorialRef);
+            StudentCourseAssociation sca2 = new StudentCourseAssociation(stuRef, courseRef, tutorialRef);
+            assertTrue(sca1.isSameSca(sca2));
+        }
+
+        @Test
+        @DisplayName("returns true when SCAs have the same IDs for student, course, tutorial but different details")
+        public void returnsTrue_sameIdsButDiffDetails() {
+            StudentCourseAssociation sca1 = new StudentCourseAssociation(stuRef, courseRef, tutorialRef);
+            StudentCourseAssociation sca2 = new StudentCourseAssociation(
+                    stuDiffName, courseDiffName, tutorialDiffCourse);
+            assertTrue(sca1.isSameSca(sca2));
+        }
+
+        @Test
+        @DisplayName("returns false when SCAs have different IDs for student, course, tutorial")
+        public void returnsTrue_differentIds() {
+            StudentCourseAssociation sca1 = new StudentCourseAssociation(stuRef, courseRef, tutorialRef);
+            StudentCourseAssociation sca2 = new StudentCourseAssociation(
+                    stuDiffMatricNo, courseDiffCode, tutorialDiffId);
+            assertFalse(sca1.isSameSca(sca2));
+        }
+    }
+
     @Test
     public void testGetCourseMethod() {
         Person student = new Person(
@@ -310,6 +353,8 @@ class StudentCourseAssociationTest {
         assertEquals(85.0, allGrades.get("Midterm"), 0.001);
         assertEquals(95.0, allGrades.get("Final"), 0.001);
     }
+
+    // ======================== UTIL METHODS ==============================================
 
     private Person createTestPerson(String matriculationNumber, String name) {
         return new Person(


### PR DESCRIPTION
That I made before working on new commands for Attendance

including but not limited to:
- `SCA::isSameSca()` - only checks matric number, course code, and tut id for equality
- `Person::genericFromMatricNumber()` - creates generic `Person` with a MatricNumber field, the rest are populated with generic values
- `Tutorial::equals()` now only checks for course code equality (`isConflictCourse()`) rather than full course equality
- Added two new SCA search methods to `SCAList`
- Other parser-related changes