### PR TITLE
fix: course commands help and error message

### DIFF
--- a/src/main/java/tahub/contacts/logic/commands/course/CourseAddCommand.java
+++ b/src/main/java/tahub/contacts/logic/commands/course/CourseAddCommand.java
@@ -18,7 +18,7 @@ public class CourseAddCommand extends Command {
     public static final String COMMAND_WORD = "course-add";
 
     public static final String MESSAGE_USAGE = COMMAND_WORD + ": Adds a course to the course book. "
-            + "eg course c/CS2103T n/Software Engineering";
+            + "eg course-add c/CS2103T n/Software Engineering";
 
     public static final String MESSAGE_SUCCESS = "New course added: %1$s";
     public static final String MESSAGE_DUPLICATE_PERSON = "This course already exists in the course book";

--- a/src/main/java/tahub/contacts/logic/commands/course/CourseDeleteCommand.java
+++ b/src/main/java/tahub/contacts/logic/commands/course/CourseDeleteCommand.java
@@ -22,7 +22,7 @@ public class CourseDeleteCommand extends Command {
 
     public static final String MESSAGE_USAGE = COMMAND_WORD
             + ": Deletes the person identified by its course code.\n"
-            + "Parameters: COURSE_CODE (must be course code of an existing course)\n"
+            + "Parameters: " + PREFIX_COURSE_CODE + "COURSE_CODE (must be course code of an existing course)\n"
             + "Example: " + COMMAND_WORD + " " + PREFIX_COURSE_CODE + "CS1101S ";
 
     public static final String MESSAGE_DELETE_COURSE_SUCCESS = "Deleted Course: %1$s";

--- a/src/main/java/tahub/contacts/logic/commands/course/CourseEditCommand.java
+++ b/src/main/java/tahub/contacts/logic/commands/course/CourseEditCommand.java
@@ -30,9 +30,9 @@ public class CourseEditCommand extends Command {
     public static final String MESSAGE_USAGE = COMMAND_WORD + ": Edits the details of the course identified "
             + "by its course code. "
             + "Existing values will be overwritten by the input values.\n"
-            + "Parameters: COURSE_CODE (must be course code of an existing course) "
+            + "Parameters: " + PREFIX_COURSE_CODE + "COURSE_CODE (must be course code of an existing course) "
             + "[" + PREFIX_NAME + "COURSE_NAME]\n"
-            + "Example: " + COMMAND_WORD
+            + "Example: " + COMMAND_WORD + " "
             + PREFIX_COURSE_CODE + "CS1101S "
             + PREFIX_NAME + "Programming basics";
 


### PR DESCRIPTION
closes #135, #160   

# Changes  

## course-add  
![image](https://github.com/user-attachments/assets/12f1495c-c771-4c42-b525-7332c35def21)

## course-edit  
![image](https://github.com/user-attachments/assets/56520f3f-347f-46c5-95cd-b2a717a77500)

## course-delete  
![image](https://github.com/user-attachments/assets/3f5f00fe-e1de-417c-874c-b743bf75e9d2)
